### PR TITLE
Add a test mode

### DIFF
--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -1,6 +1,8 @@
 require "logger"
 require "kafka"
 require "delivery_boy/version"
+require "delivery_boy/instance"
+require "delivery_boy/fake"
 require "delivery_boy/config"
 require "delivery_boy/railtie" if defined?(Rails)
 
@@ -23,13 +25,7 @@ module DeliveryBoy
     # @raise [Kafka::BufferOverflow] if the producer's buffer is full.
     # @raise [Kafka::DeliveryFailed] if delivery failed for some reason.
     def deliver(value, topic:, **options)
-      sync_producer.produce(value, topic: topic, **options)
-      sync_producer.deliver_messages
-    rescue
-      # Make sure to clear any buffered messages if there's an error.
-      sync_producer.clear_buffer
-
-      raise
+      instance.deliver(value, topic: topic, **options)
     end
 
     # Like {.deliver_async!}, but handles +Kafka::BufferOverflow+ errors
@@ -48,7 +44,7 @@ module DeliveryBoy
     #
     # @return [nil]
     def deliver_async!(value, topic:, **options)
-      async_producer.produce(value, topic: topic, **options)
+      instance.deliver_async!(value, topic: topic, **options)
     end
 
     # Shut down DeliveryBoy.
@@ -57,8 +53,7 @@ module DeliveryBoy
     #
     # @return [nil]
     def shutdown
-      sync_producer.shutdown if sync_producer?
-      async_producer.shutdown if async_producer?
+      instance.shutdown
     end
 
     # The logger used by DeliveryBoy.
@@ -77,58 +72,18 @@ module DeliveryBoy
       @config ||= DeliveryBoy::Config.new(env: ENV)
     end
 
+    def test_mode!
+      @instance = testing
+    end
+
+    def testing
+      @testing ||= Fake.new
+    end
+
     private
 
-    def sync_producer
-      # We want synchronous producers to be per-thread in order to avoid problems with
-      # concurrent deliveries.
-      Thread.current[:delivery_boy_sync_producer] ||= kafka.producer(**producer_options)
-    end
-
-    def sync_producer?
-      Thread.current.key?(:delivery_boy_sync_producer)
-    end
-
-    def async_producer
-      # The async producer doesn't have to be per-thread, since all deliveries are
-      # performed by a single background thread.
-      @async_producer ||= kafka.async_producer(
-        max_queue_size: config.max_queue_size,
-        delivery_threshold: config.delivery_threshold,
-        delivery_interval: config.delivery_interval,
-        **producer_options,
-      )
-    end
-
-    def async_producer?
-      !@async_producer.nil?
-    end
-
-    def kafka
-      @kafka ||= Kafka.new(
-        seed_brokers: config.brokers,
-        client_id: config.client_id,
-        logger: logger,
-        connect_timeout: config.connect_timeout,
-        socket_timeout: config.socket_timeout,
-        ssl_ca_cert: config.ssl_ca_cert,
-        ssl_client_cert: config.ssl_client_cert,
-        ssl_client_cert_key: config.ssl_client_cert_key,
-      )
-    end
-
-    # Options for both the sync and async producers.
-    def producer_options
-      {
-        required_acks: config.required_acks,
-        ack_timeout: config.ack_timeout,
-        max_retries: config.max_retries,
-        retry_backoff: config.retry_backoff,
-        max_buffer_size: config.max_buffer_size,
-        max_buffer_bytesize: config.max_buffer_bytesize,
-        compression_codec: config.compression_codec,
-        compression_threshold: config.compression_threshold,
-      }
+    def instance
+      @instance ||= Instance.new(config, logger)
     end
   end
 end

--- a/lib/delivery_boy/fake.rb
+++ b/lib/delivery_boy/fake.rb
@@ -1,0 +1,28 @@
+module DeliveryBoy
+
+  # A fake implementation that is useful for testing.
+  class Fake
+    FakeMessage = Struct.new(:value, :key, :topic, :partition, :partition_key)
+
+    def initialize
+      @messages = Hash.new {|h, k| h[k] = [] }
+    end
+
+    def deliver(value, topic:, **options)
+      message = FakeMessage.new(value: value, topic: topic, **options)
+      @messages[topic] << message
+
+      nil
+    end
+
+    alias deliver_async! deliver
+
+    def shutdown
+      @messages.clear
+    end
+
+    def messages_for(topic)
+      @messages[topic]
+    end
+  end
+end

--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -1,0 +1,86 @@
+module DeliveryBoy
+
+  # This class implements the actual logic of DeliveryBoy. The DeliveryBoy module
+  # has a module-level singleton instance.
+  class Instance
+    def initialize(config, logger)
+      @config = config
+      @logger = logger
+    end
+
+    def deliver(value, topic:, **options)
+      sync_producer.produce(value, topic: topic, **options)
+      sync_producer.deliver_messages
+    rescue
+      # Make sure to clear any buffered messages if there's an error.
+      sync_producer.clear_buffer
+
+      raise
+    end
+
+    def deliver_async!(value, topic:, **options)
+      async_producer.produce(value, topic: topic, **options)
+    end
+
+    def shutdown
+      sync_producer.shutdown if sync_producer?
+      async_producer.shutdown if async_producer?
+    end
+
+    private
+
+    attr_reader :config, :logger
+
+    def sync_producer
+      # We want synchronous producers to be per-thread in order to avoid problems with
+      # concurrent deliveries.
+      Thread.current[:delivery_boy_sync_producer] ||= kafka.producer(**producer_options)
+    end
+
+    def sync_producer?
+      Thread.current.key?(:delivery_boy_sync_producer)
+    end
+
+    def async_producer
+      # The async producer doesn't have to be per-thread, since all deliveries are
+      # performed by a single background thread.
+      @async_producer ||= kafka.async_producer(
+        max_queue_size: config.max_queue_size,
+        delivery_threshold: config.delivery_threshold,
+        delivery_interval: config.delivery_interval,
+        **producer_options,
+      )
+    end
+
+    def async_producer?
+      !@async_producer.nil?
+    end
+
+    def kafka
+      @kafka ||= Kafka.new(
+        seed_brokers: config.brokers,
+        client_id: config.client_id,
+        logger: logger,
+        connect_timeout: config.connect_timeout,
+        socket_timeout: config.socket_timeout,
+        ssl_ca_cert: config.ssl_ca_cert,
+        ssl_client_cert: config.ssl_client_cert,
+        ssl_client_cert_key: config.ssl_client_cert_key,
+      )
+    end
+
+    # Options for both the sync and async producers.
+    def producer_options
+      {
+        required_acks: config.required_acks,
+        ack_timeout: config.ack_timeout,
+        max_retries: config.max_retries,
+        retry_backoff: config.retry_backoff,
+        max_buffer_size: config.max_buffer_size,
+        max_buffer_bytesize: config.max_buffer_bytesize,
+        compression_codec: config.compression_codec,
+        compression_threshold: config.compression_threshold,
+      }
+    end
+  end
+end

--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -1,0 +1,15 @@
+require "delivery_boy"
+
+describe DeliveryBoy do
+  describe ".deliver_async" do
+    it "delivers the message using .deliver_async!" do
+      DeliveryBoy.test_mode!
+
+      DeliveryBoy.deliver_async("hello", topic: "greetings")
+
+      messages = DeliveryBoy.testing.messages_for("greetings")
+
+      expect(messages.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
When enabled, DeliveryBoy::Fake will handle all operations, which will be applied against a fake, in-memory message store.

During normal operations, an instance of Instance will handle everything.

This allows writing specs like:

```ruby
describe PostsController do
  describe "#show" do
    it "logs the view in a Kafka topic" do
      DeliveryBoy.test_mode!

      get :show, id: 42

      message = DeliveryBoy.testing.messages_for("post_views").first
      event = JSON.parse(message.value)

      expect(event["post_id"]).to eq 42
    end
  end
end
```

Some people may prefer to work against an actual Kafka instance when running their tests, so an explicit call to `test_mode!` is warranted.