### PR TITLE
Load a Ruby config file, if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Regarding `partition` and `partition_key`: if none are specified, DeliveryBoy wi
 
 ### Configuration
 
-You configure DeliveryBoy either through a config file or by setting environment variables.
+You configure DeliveryBoy in three different ways: in a YAML config file, in a Ruby config file, or by setting environment variables.
 
 If you're using Rails, the fastest way to get started is to execute the following in your terminal:
 
@@ -80,7 +80,16 @@ $ bundle exec rails generate delivery_boy:install
 
 This will create a config file at `config/delivery_boy.yml` with configurations for each of your Rails environments. Open that file in order to make changes.
 
-Note that for most configuration variables, you can pass in an environment variable. These environment variables all take the form `DELIVERY_BOY_X`, where `X` is the upper-case configuration variable name, e.g. `DELIVERY_BOY_CLIENT_ID`.
+Note that for all configuration variables, you can pass in an environment variable. These environment variables all take the form `DELIVERY_BOY_X`, where `X` is the upper-case configuration variable name, e.g. `DELIVERY_BOY_CLIENT_ID`.
+
+You can also configure DeliveryBoy in Ruby if you prefer that. By default, the file `config/delivery_boy.rb` is loaded if present, but you can do this from anywhere – just call `DeliveryBoy.configure` like so:
+
+```ruby
+DeliveryBoy.configure do |config|
+  config.client_id = "yolo"
+  # ...
+end
+```
 
 The following configuration variables can be set:
 

--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -74,6 +74,18 @@ module DeliveryBoy
       raise ConfigError, e.message
     end
 
+    # Configure DeliveryBoy in a block.
+    #
+    #     DeliveryBoy.configure do |config|
+    #       config.client_id = "yolo"
+    #     end
+    #
+    # @yield [DeliveryBoy::Config]
+    # @return [nil]
+    def configure
+      yield config
+    end
+
     def test_mode!
       @instance = testing
     end

--- a/lib/delivery_boy/railtie.rb
+++ b/lib/delivery_boy/railtie.rb
@@ -2,10 +2,13 @@ module DeliveryBoy
   class Railtie < Rails::Railtie
     initializer "delivery_boy.load_config" do
       config = DeliveryBoy.config
-      config_file = "config/delivery_boy.yml"
 
-      if File.exist?(config_file)
-        config.load_file(config_file, Rails.env)
+      if File.exist?("config/delivery_boy.yml")
+        config.load_file("config/delivery_boy.yml", Rails.env)
+      end
+
+      if File.exist?("config/delivery_boy.rb")
+        require "config/delivery_boy"
       end
 
       if config.datadog_enabled


### PR DESCRIPTION
If the file `config/delivery_boy.rb` is present, load it at startup. Also, provide `DeliveryBoy.configure` as an easy way to mess with the config object directly.