### PR TITLE
Bring default for authzid

### DIFF
--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -39,7 +39,7 @@ module DeliveryBoy
     # SASL authentication
     string :sasl_gssapi_principal
     string :sasl_gssapi_keytab
-    string :sasl_plain_authzid
+    string :sasl_plain_authzid, default: ''
     string :sasl_plain_username
     string :sasl_plain_password
     string :sasl_scram_username


### PR DESCRIPTION
authzid is automatically set to `nil` which makes [this
check](https://github.com/zendesk/ruby-kafka/blob/8b68a486bdc9395fca6841f515f74768ef9dc92a/lib/kafka/sasl/plain.rb#L18) to fail and so the whole connection to fail.

[This test](https://github.com/zendesk/ruby-kafka/blob/16e5cb458538d6e937bb4dbbdf62cc0308349492/spec/sasl_authenticator_spec.rb#L43-L47) says it should still work, but it's false, at least for me, my connection only happenned to be successful after I set `DELIVERY_BOY_SASL_PLAN_AUTHZID=""`.

Anyway [this test](https://github.com/zendesk/ruby-kafka/blob/16e5cb458538d6e937bb4dbbdf62cc0308349492/spec/sasl_authenticator_spec.rb#L51-L55) shows that this is a correct way to have it configured.

I understand that not everyone sets it via `SASL_PLAIN` so it can be considered as a bad default. But I spent like 3 hours looking for what I did wrong until I set that empty string, and also having that variable as an empty string, not nil, does not break anything because if you still don't set login and password, it won't go sasl plain route anyway.