### PR TITLE
Fixed error for require in railtie.rb

### DIFF
--- a/lib/delivery_boy/railtie.rb
+++ b/lib/delivery_boy/railtie.rb
@@ -8,7 +8,7 @@ module DeliveryBoy
       end
 
       if File.exist?("config/delivery_boy.rb")
-        require "config/delivery_boy"
+        require "./config/delivery_boy"
       end
 
       if config.datadog_enabled


### PR DESCRIPTION
Fixes https://github.com/zendesk/delivery_boy/issues/22.
Tried with 2.5.1 and also 2.2.10. The solution worked.