### PR TITLE
Interface synchronisation in test

### DIFF
--- a/lib/delivery_boy/fake.rb
+++ b/lib/delivery_boy/fake.rb
@@ -2,15 +2,19 @@ module DeliveryBoy
 
   # A fake implementation that is useful for testing.
   class Fake
-    FakeMessage = Struct.new(:value, :topic, :key, :offset, :partition, :partition_key)
+    FakeMessage = Struct.new(:value, :topic, :key, :offset, :partition, :partition_key, :create_time) do
+      def bytesize
+        key.to_s.bytesize + value.to_s.bytesize
+      end
+    end
 
     def initialize
       @messages = Hash.new {|h, k| h[k] = [] }
     end
 
-    def deliver(value, topic:, key: nil, partition: nil, partition_key: nil)
+    def deliver(value, topic:, key: nil, partition: nil, partition_key: nil, create_time: Time.now)
       offset = @messages[topic].count
-      message = FakeMessage.new(value, topic, key, offset, partition, partition_key)
+      message = FakeMessage.new(value, topic, key, offset, partition, partition_key, create_time)
 
       @messages[topic] << message
 

--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -5,8 +5,10 @@ describe DeliveryBoy do
     it "delivers the message using .deliver_async!" do
       DeliveryBoy.test_mode!
 
-      DeliveryBoy.deliver_async("hello", topic: "greetings")
-      DeliveryBoy.deliver_async("world", topic: "greetings")
+      time1 = Time.now
+      time2 = Time.now
+      DeliveryBoy.deliver_async("hello", topic: "greetings", create_time: time1)
+      DeliveryBoy.deliver_async("world", topic: "greetings", create_time: time2)
 
       messages = DeliveryBoy.testing.messages_for("greetings")
 
@@ -14,9 +16,11 @@ describe DeliveryBoy do
 
       expect(messages[0].value).to eq "hello"
       expect(messages[0].offset).to eq 0
+      expect(messages[0].create_time).to eq time1
 
       expect(messages[1].value).to eq "world"
       expect(messages[1].offset).to eq 1
+      expect(messages[1].create_time).to eq time2
     end
   end
 end


### PR DESCRIPTION
This PR makes the interfaces of the `Fake` instance and `FakeMessage` more similar to their production equivalents. This makes it possible to write more robust unit tests of DeliveryBoy code. 

- Allow fake instance to receive create_time for testing
- Add bytesize method to test instance