### PR TITLE
RSpec - avoid using monkey_patching mode

### DIFF
--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -1,6 +1,6 @@
 require "delivery_boy"
 
-describe DeliveryBoy do
+RSpec.describe DeliveryBoy do
   describe ".deliver_async" do
     it "delivers the message using .deliver_async!" do
       DeliveryBoy.test_mode!


### PR DESCRIPTION
This PR changes one spec file, to enable the zero-monkey-patching mode of RSpec.