### PR TITLE
Avoid a Ruby warning on un-inited ivar

### DIFF
--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -6,6 +6,7 @@ module DeliveryBoy
     def initialize(config, logger)
       @config = config
       @logger = logger
+      @async_producer = nil
     end
 
     def deliver(value, topic:, **options)


### PR DESCRIPTION
This PR avoids a Ruby warning like 

`/Users/olle/.rvm/gems/ruby-2.5.3/gems/delivery_boy-0.2.7/lib/delivery_boy/instance.rb:56: warning: instance variable @async_producer not initialized`