### PR TITLE
Allows test_mode! to be limited in scope

### DIFF
--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -86,6 +86,14 @@ module DeliveryBoy
       yield config
     end
 
+    def with_test_mode(&block)
+      prev_instance = @instance
+      test_mode!
+      block.call
+    ensure
+      @instance = prev_instance
+    end
+
     def test_mode!
       @instance = testing
     end


### PR DESCRIPTION
This makes it easier to have both unit and full integration specs in the
same project that has a dependency on Delivery Boy.