### PR TITLE
Support log_level config option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support `log_level` config option.
+
 ## v0.2.8
 
 * Upgrade dependency on KingKonf.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ A list of Kafka brokers that should be used to initialize the client. Defaults t
 
 This is how the client will identify itself to the Kafka brokers. Default is `delivery_boy`.
 
+##### `log_level`
+
+The log level for the logger.
+
 #### Message delivery
 
 ##### `delivery_interval`
@@ -231,17 +235,17 @@ describe PostsController do
   describe "#show" do
     it "emits an event to Kafka" do
       post = Post.create!(body: "hello")
-      
+
       get :show, id: post.id
-      
+
       # Use this API to extract all messages written to a Kafka topic.
       messages = DeliveryBoy.testing.messages_for("post_views")
-      
+
       expect(messages.count).to eq 1
-      
+
       # In addition to #value, you can also pull out #key and #partition_key.
       event = JSON.parse(messages.first.value)
-      
+
       expect(event["post_id"]).to eq post.id
     end
   end

--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -60,7 +60,11 @@ module DeliveryBoy
     #
     # @return [Logger]
     def logger
-      @logger ||= Logger.new($stdout)
+      @logger ||= Logger.new($stdout).tap do |logger|
+        if config.log_level
+          logger.level = Object.const_get("Logger::#{config.log_level.upcase}")
+        end
+      end
     end
 
     attr_writer :logger

--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -7,6 +7,7 @@ module DeliveryBoy
     # Basic
     list :brokers, items: :string, sep: ",", default: ["localhost:9092"]
     string :client_id, default: "delivery_boy"
+    string :log_level, default: nil
 
     # Buffering
     integer :max_buffer_bytesize, default: 10_000_000


### PR DESCRIPTION
This PR adds support for `log_level` config option. Similar to same option in Racecar (https://github.com/zendesk/racecar/pull/35).