### PR TITLE
Added methods to queue multiple messages before sending them synchronously.

### DIFF
--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -28,6 +28,14 @@ module DeliveryBoy
       async_producer.shutdown if async_producer?
     end
 
+    def produce(value, topic:, **options)
+      sync_producer.produce(value, topic: topic, **options)
+    end
+
+    def deliver_messages
+      sync_producer.deliver_messages
+    end
+
     private
 
     attr_reader :config, :logger

--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -1,6 +1,10 @@
 require "delivery_boy"
 
 RSpec.describe DeliveryBoy do
+  after(:each) do
+    DeliveryBoy.testing.clear
+  end
+
   describe ".deliver_async" do
     it "delivers the message using .deliver_async!" do
       DeliveryBoy.test_mode!
@@ -9,6 +13,41 @@ RSpec.describe DeliveryBoy do
       time2 = Time.now
       DeliveryBoy.deliver_async("hello", topic: "greetings", create_time: time1)
       DeliveryBoy.deliver_async("world", topic: "greetings", create_time: time2)
+
+      messages = DeliveryBoy.testing.messages_for("greetings")
+
+      expect(messages.count).to eq 2
+
+      expect(messages[0].value).to eq "hello"
+      expect(messages[0].offset).to eq 0
+      expect(messages[0].create_time).to eq time1
+
+      expect(messages[1].value).to eq "world"
+      expect(messages[1].offset).to eq 1
+      expect(messages[1].create_time).to eq time2
+    end
+  end
+
+  describe ".produce and .deliver_messages" do
+    it "does not send produced messages without calling deliver_messages" do
+      DeliveryBoy.test_mode!
+
+      time1 = Time.now
+      time2 = Time.now
+      DeliveryBoy.produce("hello", topic: "greetings", create_time: time1)
+      DeliveryBoy.produce("world", topic: "greetings", create_time: time2)
+
+      expect(DeliveryBoy.testing.messages_for("greetings").count).to eq 0
+    end
+
+    it "sends produced messages after calling deliver_messages" do
+      DeliveryBoy.test_mode!
+
+      time1 = Time.now
+      time2 = Time.now
+      DeliveryBoy.produce("hello", topic: "greetings", create_time: time1)
+      DeliveryBoy.produce("world", topic: "greetings", create_time: time2)
+      DeliveryBoy.deliver_messages
 
       messages = DeliveryBoy.testing.messages_for("greetings")
 

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -17,4 +17,11 @@ RSpec.describe DeliveryBoy::Instance do
       instance.shutdown
     end
   end
+
+  describe "#produce and #deliver_messages" do
+    it "produces and delivers a message to kafka" do
+      instance.produce("hello", topic: "greeting")
+      instance.deliver_messages
+    end
+  end
 end


### PR DESCRIPTION
DeliveryBoy only allows the synchronous way of sending a single message. We have a use-case where we want to send a batch of messages, but for performance reasons we want to send them all together.

I've added two methods that basically split the behaviour of `deliver` into two separate methods: `produce` and `deliver_messages`. The first adds the message to the internal buffer, and the second method sends the complete buffer in a blocking, synchronous way to Kafka.