### PR TITLE
Allow setting sasl_over_ssl in config.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 ## v0.2.8
 
 * Upgrade dependency on KingKonf.
+* Allow configuring `sasl_over_ssl`.
 
 ## v0.2.7
 

--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -46,6 +46,7 @@ module DeliveryBoy
     string :sasl_scram_username
     string :sasl_scram_password
     string :sasl_scram_mechanism
+    boolean :sasl_over_ssl, default: true
 
     # Datadog monitoring
     boolean :datadog_enabled

--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -77,6 +77,7 @@ module DeliveryBoy
         sasl_scram_username: config.sasl_scram_username,
         sasl_scram_password: config.sasl_scram_password,
         sasl_scram_mechanism: config.sasl_scram_mechanism,
+        sasl_over_ssl: config.sasl_over_ssl
       )
     end
 


### PR DESCRIPTION
Allow sassl_over_ssl config to be available for delivery_boy
   when initializing kafka_client.