### PR TITLE
support for ssl_verify_hostname in the configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 
 # rspec failure tracking
 .rspec_status
-.idea/

--- a/delivery_boy.gemspec
+++ b/delivery_boy.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "ruby-kafka", "~> 0.5"
+  spec.add_runtime_dependency "ruby-kafka", "~> 0.7.8"
   spec.add_runtime_dependency "king_konf", "~> 0.3"
 
   spec.add_development_dependency "bundler", "~> 1.15"

--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -36,6 +36,7 @@ module DeliveryBoy
     string :ssl_client_cert, default: nil
     string :ssl_client_cert_key, default: nil
     boolean :ssl_ca_certs_from_system, default: false
+    boolean :ssl_verify_hostname, default: true
 
     # SASL authentication
     string :sasl_gssapi_principal

--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -77,6 +77,7 @@ module DeliveryBoy
         ssl_client_cert: config.ssl_client_cert,
         ssl_client_cert_key: config.ssl_client_cert_key,
         ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
+        ssl_verify_hostname: config.ssl_verify_hostname,
         sasl_gssapi_principal: config.sasl_gssapi_principal,
         sasl_gssapi_keytab: config.sasl_gssapi_keytab,
         sasl_plain_authzid: config.sasl_plain_authzid,


### PR DESCRIPTION
ruby-kafka introduce new configuration property that solve a critical issue when connecting to Heroku with SSL: [SSL verification breaks Heroku Kafka #734](https://github.com/zendesk/ruby-kafka/issues/734)
Without this fix I wasn't able to connect to heroku's Kafka with delivery_boy