### PR TITLE
Implement `DeliveryBoy::Fake::FakeMessage#headers` attribute for tests

### DIFF
--- a/lib/delivery_boy/fake.rb
+++ b/lib/delivery_boy/fake.rb
@@ -2,7 +2,7 @@ module DeliveryBoy
 
   # A fake implementation that is useful for testing.
   class Fake
-    FakeMessage = Struct.new(:value, :topic, :key, :offset, :partition, :partition_key, :create_time) do
+    FakeMessage = Struct.new(:value, :topic, :key, :headers, :offset, :partition, :partition_key, :create_time) do
       def bytesize
         key.to_s.bytesize + value.to_s.bytesize
       end
@@ -14,10 +14,10 @@ module DeliveryBoy
       @delivery_lock = Mutex.new
     end
 
-    def deliver(value, topic:, key: nil, partition: nil, partition_key: nil, create_time: Time.now)
+    def deliver(value, topic:, key: nil, headers: {}, partition: nil, partition_key: nil, create_time: Time.now)
       @delivery_lock.synchronize do
         offset = @messages[topic].count
-        message = FakeMessage.new(value, topic, key, offset, partition, partition_key, create_time)
+        message = FakeMessage.new(value, topic, key, headers, offset, partition, partition_key, create_time)
 
         @messages[topic] << message
       end
@@ -27,10 +27,10 @@ module DeliveryBoy
 
     alias deliver_async! deliver
 
-    def produce(value, topic:, key: nil, partition: nil, partition_key: nil, create_time: Time.now)
+    def produce(value, topic:, key: nil, headers: {}, partition: nil, partition_key: nil, create_time: Time.now)
       @delivery_lock.synchronize do
         offset = @buffer[topic].count
-        message = FakeMessage.new(value, topic, key, offset, partition, partition_key, create_time)
+        message = FakeMessage.new(value, topic, key, headers, offset, partition, partition_key, create_time)
 
         @buffer[topic] << message
       end


### PR DESCRIPTION
Addresses #43

`ruby-kafka` implements a `headers` attribute for their [`PendingMessage` class](https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/pending_message.rb#L7), allowing a hash to be passed through for reading without having to parse the body (value) of the message.

This is supported out-of-the-box in the way that delivery_boy passes any options to that library, but not in tests, because the `DeliveryBoy::Fake::FakeMessage` class is missing the attribute, so I've added that attribute in this PR.