### PR TITLE
Check that Rails::Railtie is defined

### DIFF
--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -4,7 +4,7 @@ require "delivery_boy/version"
 require "delivery_boy/instance"
 require "delivery_boy/fake"
 require "delivery_boy/config"
-require "delivery_boy/railtie" if defined?(Rails)
+require "delivery_boy/railtie" if defined?(Rails::Railtie)
 
 module DeliveryBoy
   class << self


### PR DESCRIPTION
`Rails` namespace can be defined without Railtie which can cause
NameErrors. This tightens the scope of `defined?` check to specifically
check if `Rails::Railtie` has been loaded.