### PR TITLE
Supports exactly once delivery and transactional messaging

### DIFF
--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -25,6 +25,9 @@ module DeliveryBoy
     integer :max_retries, default: 2
     integer :required_acks, default: -1
     integer :retry_backoff, default: 1
+    boolean :idempotent, default: false
+    boolean :transactional, default: false
+    integer :transactional_timeout, default: 60
 
     # Compression
     integer :compression_threshold, default: 1

--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -105,6 +105,9 @@ module DeliveryBoy
         max_buffer_bytesize: config.max_buffer_bytesize,
         compression_codec: (config.compression_codec.to_sym if config.compression_codec),
         compression_threshold: config.compression_threshold,
+        idempotent: config.idempotent,
+        transactional: config.transactional,
+        transactional_timeout: config.transactional_timeout,
       }
     end
   end


### PR DESCRIPTION
👋 I ran into a situation where it'd be helpful to have an idempotent producer. Based on https://github.com/zendesk/ruby-kafka/pull/608, I believe these configuration changes are all that's necessary to support this.

One important thing to note is that as-written I don't believe we can support the `transactional_id` as we don't have a way to "reset" the producer we're reusing.

The defaults for the configuration options come from here: https://github.com/zendesk/ruby-kafka/blob/e22fded91869427f25392ba74c506e2262b31639/lib/kafka/client.rb#L257-L260