### PR TITLE
Support for ssl_client_cert_key_password in config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Support for `ssl_client_cert_key_password` in the configuration (#52)
+
 ## v1.0.1
 
 * Require ruby-kafka v1.0 or higher.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ A PEM encoded client cert key to use with an SSL connection. Must be used in com
 
 ##### `ssl_client_cert_key_password`
 
-A password for PEM encoded client cert to use with an SSL connection.
+The password required to read the ssl_client_cert_key. Must be used in combination with ssl_client_cert_key.
 
 #### SASL Authentication and authorization
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ A PEM encoded client cert to use with an SSL connection. Must be used in combina
 
 A PEM encoded client cert key to use with an SSL connection. Must be used in combination with `ssl_client_cert`.
 
+##### `ssl_client_cert_key_password`
+
+A password for PEM encoded client cert to use with an SSL connection.
+
 #### SASL Authentication and authorization
 
 See [ruby-kafka](https://github.com/zendesk/ruby-kafka#authentication-using-sasl) for more information.

--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -38,6 +38,7 @@ module DeliveryBoy
     string :ssl_ca_cert_file_path
     string :ssl_client_cert, default: nil
     string :ssl_client_cert_key, default: nil
+    string :ssl_client_cert_key_password, default: nil
     boolean :ssl_ca_certs_from_system, default: false
     boolean :ssl_verify_hostname, default: true
 

--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -80,6 +80,7 @@ module DeliveryBoy
         ssl_ca_cert_file_path: config.ssl_ca_cert_file_path,
         ssl_client_cert: config.ssl_client_cert,
         ssl_client_cert_key: config.ssl_client_cert_key,
+        ssl_client_cert_key_password: config.ssl_client_cert_key_password,
         ssl_ca_certs_from_system: config.ssl_ca_certs_from_system,
         ssl_verify_hostname: config.ssl_verify_hostname,
         sasl_gssapi_principal: config.sasl_gssapi_principal,


### PR DESCRIPTION
Ruby-Kafka have option `ssl_client_cert_key_password` for SSL Client Authentication. I added this option to `delivery_boy`.