### PR TITLE
bring test helper up-to-date to runtime's API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
 
 * Support for `ssl_client_cert_key_password` in the configuration (#52)
 * Add `DeliveryBoy.buffer_size` to return the number of messages in the buffer
+* Add `DeliveryBoy::Fake#clear_buffer` and `DeliveryBoy::Fake#buffer_size` to
+support the public API when using the test helper.
 
 ## v1.0.1
 

--- a/lib/delivery_boy/fake.rb
+++ b/lib/delivery_boy/fake.rb
@@ -51,6 +51,18 @@ module DeliveryBoy
       clear
     end
 
+    def clear_buffer
+      @delivery_lock.synchronize do
+        @buffer.clear
+      end
+    end
+
+    def buffer_size
+      @delivery_lock.synchronize do
+        @buffer.values.flatten.size
+      end
+    end
+
     # Clear all messages stored in memory.
     def clear
       @delivery_lock.synchronize do

--- a/spec/fake_spec.rb
+++ b/spec/fake_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe DeliveryBoy::Fake do
+  it "should match the public API" do
+    aggregate_failures do
+      DeliveryBoy::Instance.public_instance_methods(false).each do |public_method|
+        expect(described_class.public_instance_methods).to include public_method
+      end
+    end
+  end
+end


### PR DESCRIPTION
`DeliveryBoy::Instance` supports `#clear_buffer` and `#buffer_size` methods,
which are not implemented on `DeliveryBoy::Fake`, throwing an `NME` when
testing implementations that rely on either of these.