### PR TITLE
Fixup error on invalid envvar config

### DIFF
--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -4,6 +4,7 @@ require "delivery_boy/version"
 require "delivery_boy/instance"
 require "delivery_boy/fake"
 require "delivery_boy/config"
+require "delivery_boy/config_error"
 require "delivery_boy/railtie" if defined?(Rails::Railtie)
 
 module DeliveryBoy

--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -62,4 +62,15 @@ RSpec.describe DeliveryBoy do
       expect(messages[1].create_time).to eq time2
     end
   end
+
+  describe "with invalid config in ENV" do
+    before { ENV["DELIVERY_BOY_ACK_TIMEOUT"] = "true" }
+    after { ENV.delete("DELIVERY_BOY_ACK_TIMEOUT") }
+
+    it "raises ConfigError" do
+      DeliveryBoy.test_mode!
+
+      expect { DeliveryBoy.config }.to raise_error(DeliveryBoy::ConfigError, '"true" is not an integer')
+    end
+  end
 end


### PR DESCRIPTION
Without require we have 
```
Failures:

  1) DeliveryBoy with invalid config in ENV raises ConfigError
     Failure/Error: expect { DeliveryBoy.config }.to raise_error(DeliveryBoy::ConfigError, '"true" is not an integer')

     NameError:
       uninitialized constant DeliveryBoy::ConfigError
       Did you mean?  EncodingError
     # ./spec/delivery_boy_spec.rb:73:in `block (3 levels) in <top (required)>'
```