### PR TITLE
Fix brokers for Ruby 3

### DIFF
--- a/lib/delivery_boy/instance.rb
+++ b/lib/delivery_boy/instance.rb
@@ -75,7 +75,7 @@ module DeliveryBoy
 
     def kafka
       @kafka ||= Kafka.new(
-        seed_brokers: config.brokers,
+        config.brokers,
         client_id: config.client_id,
         logger: logger,
         connect_timeout: config.connect_timeout,


### PR DESCRIPTION
**Issue**: Brokers defined in the config `delivery_boy.yml` are not being set.

**Reason**: The constructor of `Kafka` class in `ruby-kafka` [gem](https://github.com/zendesk/ruby-kafka/) takes two arguments, 1. brokers, 2. options. See [reference](https://github.com/zendesk/ruby-kafka/blob/d5def61ad82ca6ed2645939c202ec967208d7787/lib/kafka.rb#L362) 