### PR TITLE
`delivery_interval` should allow floats

### DIFF
--- a/lib/delivery_boy/config.rb
+++ b/lib/delivery_boy/config.rb
@@ -20,7 +20,7 @@ module DeliveryBoy
 
     # Delivery
     integer :ack_timeout, default: 5
-    integer :delivery_interval, default: 10
+    float :delivery_interval, default: 10
     integer :delivery_threshold, default: 100
     integer :max_retries, default: 2
     integer :required_acks, default: -1

--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe DeliveryBoy do
     end
   end
 
+  describe ".configure changes config" do
+    DeliveryBoy.configure do |config|
+      config.delivery_interval = 0.05
+    end
+
+    expect(DeliveryBoy.config.delivery_interval).to eq 0.05
+  end
+
   describe ".produce and .deliver_messages" do
     it "does not send produced messages without calling deliver_messages" do
       DeliveryBoy.test_mode!

--- a/spec/delivery_boy_spec.rb
+++ b/spec/delivery_boy_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe DeliveryBoy do
     end
   end
 
-  describe ".configure changes config" do
-    DeliveryBoy.configure do |config|
-      config.delivery_interval = 0.05
-    end
+  describe ".configure" do
+    it "allows float for .delivery_interval" do
+      DeliveryBoy.configure do |config|
+        config.delivery_interval = 0.05
+      end
 
-    expect(DeliveryBoy.config.delivery_interval).to eq 0.05
+      expect(DeliveryBoy.config.delivery_interval).to eq 0.05
+    end
   end
 
   describe ".produce and .deliver_messages" do


### PR DESCRIPTION
Change from `integer` to `float` for `delivery_interval` in `Config`.

Also tests that `delivery_interval` default can be overriden.