### PR TITLE
Remove the DeliveryBoy::Instance object on shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+## v1.3.0
+
 * Remove the `DeliveryBoy::Instance` instance when calling
 `DeliveryBoy.shutdown`. (#82)
+* Test with Ruby 3.3 & 3.4.
 
 ## v1.2.0
 
-* Test with Ruby 3.1 & 3.2
+* Test with Ruby 3.1 & 3.2.
 * Add config support for AWS MSK IAM auth (#66)
 
 ## v1.1.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Remove the `DeliveryBoy::Instance` instance when calling
+`DeliveryBoy.shutdown`. (#82)
+
 ## v1.2.0
 
 * Test with Ruby 3.1 & 3.2

--- a/lib/delivery_boy.rb
+++ b/lib/delivery_boy.rb
@@ -98,6 +98,7 @@ module DeliveryBoy
     # @return [nil]
     def shutdown
       instance.shutdown
+      @instance = nil
     end
 
     # The logger used by DeliveryBoy.

--- a/lib/delivery_boy/version.rb
+++ b/lib/delivery_boy/version.rb
@@ -1,3 +1,3 @@
 module DeliveryBoy
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Just be on the safe side when operating with multiple forks, let's remove the `DeliveryBoy::Instance` instance when calling `DeliveryBoy.shutdown`.